### PR TITLE
Minor edits and new HTML examples

### DIFF
--- a/book/12-e-csound-on-android.md
+++ b/book/12-e-csound-on-android.md
@@ -41,18 +41,18 @@ five push buttons, one trackpad, and a 3-dimensional accelerometer that
 are pre-assigned to control channels which can be read using Csound's
 [chnget](https://csound.com/docs/manual/chnget.html) opcode.  
 
-The app also contains an embedded Web browser, based on WebKit, that can
-parse, interpret, and present HTML and JavaScript code that is contained
-in the `<html>` element of the CSD file. The embedded browser implements
-most features of the HTML5 standard. Selected commonly used functions
-from the Csound API are available from JavaScript embedded in this `<html>` 
-code, and can be used to control Csound from HTML user interfaces, generate 
-scores, and do many other things. For a more complete introduction to the use 
-of HTML with Csound, see chapter [12 G](12-g-csound-and-html.md). On Android, 
-if the `<html>` element is present in the CSD file, the HTML tab of the app 
-will display a Web page that has been constructed from the code in the `<html>` 
-element of the CSD. The app will also perform .html files that use the embedded 
-Csound object.
+The app also contains an embedded Web browser, based on WebKit, that 
+implements most features of the HTML5 standard. This embedded browser can
+run Csound pieces written as .html files. In addition, the app can render HTML 
+and JavaScript code that is contained in an optional `<html>` element of a 
+regular .csd file. 
+
+In both cases, the JavaScript context of the Web page will contain a global 
+Csound object with a JavaScript interface that implements useful functions 
+of the Csound API. This can be used to control Csound from JavaScript, handle 
+events from HTML user interfaces, generate scores, and do many other things. 
+For a more complete introduction to the use of HTML with Csound, see 
+[12 G](12-g-csound-and-html.md). 
 
 The app has some limitations and missing features compared with the
 longer-established platforms:
@@ -81,7 +81,14 @@ There are several ways to install the Csound for Android app. You can download i
 your device, or you can download it to a computer and transfer it to
 your device. These methods are presented below.  
 
-### Preparing Your Device
+### Google Play Store
+
+The most straightforward way to install the Csound for Android app is 
+to get it from the [Google Play Store](https://play.google.com/store/apps/details?id=com.csounds.Csound6).
+
+### Install from Another Source
+
+#### Preparing Your Device
 
 Using the *Csound for Android app* is similar to using an application on a regular
 computer. You need to be able to browse the file system.  
@@ -96,7 +103,7 @@ I have found that the free
 app can do this.  
 
 If you render soundfiles, they take up a lot of space. For example,
-CD-quality stereo soundfiles (44.1 KHz, 16 bit) take up about 10
+CD-quality stereo soundfiles (44.1 KHz, 16 bit) take up about 1
 megabytes per minute of sound. Higher quality or more channels take up
 even more room. But even without extra storage, a modern smartphone
 should have gigabytes, thousands of megabytes, of free storage. This is
@@ -107,19 +114,13 @@ expensive. I recommend obtaining the largest possible SD card, if your
 device supports them. This will vastly expand the amount of available
 space, up to 32 or 64 gigabytes or even more.  
 
-### Google Play Store
-
-The most straightforward way to install the Csound for Android app is 
-to get it from the [Google Play Store](https://play.google.com/store/apps/details?id=com.csounds.Csound6).
-
-
-### Download to Device
+#### Download to Device
 
 To download the Csound for Android app to your device, go online using Google
 Search or a Web browser. You can find the application package file,
 CsoundApplication-release.apk, on the
 [csound-extended releases page](https://github.com/gogins/csound-extended/releases)
-(you may first have to allow your android to install an app which is not
+(you may first have to allow your Android device to install an app which is not
 in Google Play).  
 
 Click on the filename to download the package. The download will happen
@@ -128,8 +129,7 @@ device and click on the downloaded file. You will be presented with one
 or more options for how to install it. The installer will ask for
 certain permissions, which you need to grant.  
 
-
-### Transfer from a Computer
+#### Transfer from a Computer
 
 It's also easy to download the CsoundApplication-release.apk file to a personal computer.
 Once you have downloaded the file from GitHub, connect your device
@@ -148,6 +148,8 @@ permissions, which you should give.
 
 User Interface
 --------------
+
+### Tabs
 
 The Csound for Android app has a tabbed user interface. The tabs include:
 
@@ -174,6 +176,8 @@ The Csound for Android app has a tabbed user interface. The tabs include:
                   
 -   ***ABOUT*** -- Displays the Csound home page in an embedded Web browser.
 
+### Main Menu
+
 The app also has a top-level menu with the following commands:
 
 -   ***NEW...*** -- creates a blank template CSD file in the root directory
@@ -188,7 +192,7 @@ The app also has a top-level menu with the following commands:
 
 -   ***RUN/STOP*** -- if a CSD file has been loaded, pushing the
     button starts running Csound; if Csound is running, pushing the
-    button stops Csound. If the \<CsOptions\> element of the CSD file
+    button stops Csound. If the `<CsOptions>` element of the CSD file
     contains `-odac`, Csound's audio output will go to the device audio
     output. If the element contains `-osoundfilename`, Csound\'s audio
     output will go to the file `soundfilename`, which should be a valid
@@ -216,7 +220,7 @@ read into Csound during performance using the *chnget* opcode, like this:
 The area below the trackpad prints messages output by Csound as it runs.
 
 
-### The Settings Menu
+### Settings Menu
 
 The Settings menu on your device offers the following choices:
 
@@ -258,8 +262,8 @@ headphone jack to your sound system with an adapter cable. Most devices
 have reasonably high quality audio playback capabilities, so this can
 work quite well.
 
-Just to prove that everything is working, start the *Csound for Android* app. Go to
-the app menu, select the *Examples* item, select the *Xanadu*
+Just to prove that everything is working, start the Csound for Android app. Go 
+to the app menu, select the *Examples* item, select the *Xanadu*
 example, and it will be loaded into Csound. Then click on the *RUN*
 command. Its name should change to *STOP*, and Csound's runtime messages
 should begin to scroll down the *MESSAGES* tab. At the same time, you should 
@@ -295,12 +299,12 @@ another place if you like.
 The text editor should open with a *template* CSD file. Your job is to
 fill out this template to hear something.
 
-Create a blank line between \<CsOptions\> and \</CsOptions\>, and type
-*-odac -d -m3*. This means send audio to the real-time output (*-odac*), do
-not display any function tables (*-d*), and log some informative messages
-during Csound's performance (*-m3*).
+Create a blank line between `<CsOptions>` and `</CsOptions>`, and type
+`-odac -d -m3`. This means send audio to the real-time output (`-odac`), do
+not display any function tables (`-d`), and log some informative messages
+during Csound's performance (`-m3`).
 
-Create a blank line between \<CsInstruments\> and \</CsInstruments\> and
+Create a blank line between `<CsInstruments>` and `</CsInstruments>` and
 type the following text:
 
     sr = 44100
@@ -318,7 +322,7 @@ second, with 32 audio frames per control signal sample, and one channel
 of audio output. The instrument is just a simple sine oscillator. It
 plays a tone at concert A.
 
-Create a blank line between \<CsScore\> and \</CsScore\> and type:
+Create a blank line between `<CsScore>` and `</CsScore>` and type:
 
     i1 0 5
 
@@ -330,8 +334,8 @@ Select the Csound app's *RUN* button. You should hear a loud sine
 tone for 5 seconds. If you don't hear anything, perhaps your device 
 doesn't support audio at 44100 Hertz, so try `sr = 48000` instead.  
 
-If you want to save your audio output to a soundfile named *test.wav*,
-change *-odac* above to, for example, *-o/storage/emulated/0/Music/test.wav*. Android is fussy about 
+If you want to save your audio output to a soundfile named `test.wav`,
+change `-odac` above to, for example, `-o/storage/emulated/0/Music/test.wav`. Android is fussy about 
 writing to device storage, so you may need to use exactly the directory printed 
 in the ***MESSAGES*** tab when the app starts.  
 
@@ -344,21 +348,14 @@ Using the Widgets
 This section shows how to use the built-in widgets of the Csound for
 Android app for controlling Csound in performance. For instructions on
 how to use the `<html>` element of the CSD file to create custom user
-interfaces, see the
-[Csound and HTML](12-g-csound-and-html.md)
- chapter of this book.
+interfaces, see the [Csound and HTML](12-g-csound-and-html.md) chapter of 
+this book.
 
 The Csound for Android app provides access to a set of predefined
 on-screen widgets, as well as to the accelerometer on the device. All of
 these controllers are permanently assigned to pre-defined control
 channels with pre-defined names, and mapped to a pre-defined range of
 values, from 0 to 1.
-
-All of this pre-definitions -- this is both good and bad. I have found,
-following the example of Iain McCurdy who has graciously contributed a
-number of the examples for the app, an approach that simplifies using
-the controllers. For an example of this approach in action, look at the
-source code for the *Gogins/Drone-IV.csd* example.
 
 You should be able to cut and paste this code into your own pieces
 without many changes.

--- a/book/12-g-csound-and-html.md
+++ b/book/12-g-csound-and-html.md
@@ -13,7 +13,10 @@ in at least the following environments:
 4. Csound built for WebAssembly, which has two slightly different forms:
 
    1. The canonical build, described in [10 F](10-f-web-based-csound.md).
-   2. [The csound-extended build](https://github.com/gogins/csound-extended/tree/develop/WebAssembly).
+   2. The [csound-extended](https://github.com/gogins/csound-extended/tree/develop/WebAssembly) build.
+   
+For instructions on installing any of these environments, please consult the 
+documentation provided in the links mentioned above.
 
 All of these environments provide a JavaScript interface to Csound, 
 which appears as a global Csound object in the JavaScript context of a Web 
@@ -23,18 +26,22 @@ to Csound between these environments.
 With HTML and JavaScript it is possible to define user interfaces, to
 control Csound, and to generate Csound scores and even orchestras. 
 
-In some environments, the HTML code may be embedded in an optional `<html>` 
-element of the Csound Structured Data (CSD) file. This element essentially defines a Web page
-that contains Csound. 
+In all of these environments, a piece may be written in the form of a Web page 
+(an .html file), with access to a global instance of Csound that exists in the 
+JavaScript context of that Web page. In such pieces, it is common to embed the 
+entire .orc or .csd file for Csound into the .html code as a JavaScript multiline 
+string literal or an invisible TextArea widget.
 
-In other environments, Csound is embedded in a regular Web page (.html file). 
+In CsoundQt and Csound for Android, the HTML code may be embedded in an optional 
+`<html>` element of the Csound Structured Data (.csd) file. This element
+essentially defines a Web page that contains Csound, but the host application 
+is responsible for editing the Csound orchestra and running it.
 
 This chapter is organized as follows:
 
 1.  Introduction (this section)
-2.  Installation
-3.  Tutorial User's Guide
-4.  Conclusion
+2.  Tutorial User's Guide
+3.  Conclusion
 
 HTML must be understood here to represent not only Hyper Text Markup
 Language, but also all of the other Web standards that currently are
@@ -54,46 +61,36 @@ consistency. To see what features are available in your own Web browser,
 go to this [test page](https://html5test.com/). All of this stuff is now
 usable in Csound pieces.
 
-
-### Examples of Use
+### An Example of Use
 
 For an example of a few of the things are possible with HTML in Csound,
-take a look at the following screen shots. Both of these examples are
-included in the Windows installer for Csound, which also includes the
-HTML-enabled version of CsoundQt.
+take a look at the following piece, ***Scrims***, which runs in contemporary 
+Web browsers using a WebAssembly build of Csound and JavaScript code. In 
+fact, it's running right here on this page!
 
-![](../resources/images/12-g-gameoflife3d.png)
+![](https://gogins.github.io/csound-extended/scrims.html){width=100% height=600px object-fit=contain}
 
-In this figure, *GameOfLife3d.csd* demonstrates the following features of
-HTML: style sheets for formatting the legend, WebGL for displaying a
-rotating 3-dimensional form of John Conway's *Game of Life* with shifting
-lighting, animation which "tweens" the cubes from one state of the
-game to the next, and the Csound API. The JavaScript code that generates
-the display also builds up a chunk of Csound score that is sent to
-Csound. Thus, each new state of the game plays a chord using Csound
-instruments.  The user can interact with the game, rotating it and
-zooming it.
+***Scrims*** is a demanding piece, and may not run without dropouts unless you 
+have a rather fast computer. However, it demonstrates a number of ways to use 
+HTML and JavaScript with Csound:
 
-![](../resources/images/12-g-lindenmayercanvas.png)
+1. Use of the [Three.js](https://threejs.org/) library to generate a 3-dimensional animated image of 
+   the popcorn fractal.
+2. Use of an external JavaScript library, 
+   [silencio](https://github.com/gogins/csound-extended/tree/develop/silencio), to sample the moving 
+   image and to generate Csound notes from it, that are sent to Csound in real time 
+   with the Csound API `csound.readScore` function.
+3. Use of a complex Csound orchestra that is embedded in a hidden TextArea on 
+   the page.
+4. Use of the [dat.gui](https://github.com/dataarts/dat.gui) library to easily 
+   create sliders and buttons for controlling the piece in real time.
+5. Use of the [jQuery](https://jquery.com/) library to simplify handling events from sliders, 
+   buttons, and other HTML elements.
+6. Use of a TextArea widget as a scrolling display for Csound's runtime messages.
 
-In the *LindenmayerCanvas.csd* shown here, the HTML code is used to do these
-things:
-
-1.  Define slider widgets for controlling Csound with the channel API,
-    using HTML input elements with JavaScript event handlers.
-2.  Style the sliders and the table containing them with a Custom Style
-    Sheet (CSS).
-3.  Save the positions of the widgets when the *Save control values*
-    button is clicked, and restore the positions of the widgets when the
-    *Restore control values* button is clicked, using the Local
-    Storage feature of HTML5. These values are retrieved whenever the
-    piece is loaded.
-4.  Use JavaScript to define a context-free Lindenmayer system for
-    generating not only the tree image drawn on the HTML Canvas at the
-    bottom of the screen, but also a Csound score representing the tree,
-    when the *Generate score* button is clicked. Being able to see
-    some sort of graphical representation of a score is very useful when
-    doing algorithmic composition.
+To see this code in action, you can right-click on the piece and select the 
+***Inspect*** command. Then you can browse the source code, set breakpoints, 
+print values of variables, and so on.
 
 It is true that LaTeX can do a better job of typesetting than HTML and
 CSS. It is true that game engines can do a better job for interactive,
@@ -115,7 +112,6 @@ So I believe HTML as a front end for Csound should be quite stable and
 remain backwardly compatible, just as Csound itself remains backwardly
 compatible with old pieces.
 
-
 ### How it Works
 
 The Web browser embedded into CsoundQt is the
@@ -125,13 +121,14 @@ The Web browser embedded into Csound for Android is the
 available in the
 [Android SDK](https://developer.android.com/index.html).
 
-The front end parses the `<html>` element out of the CSD file and simply
-saves it as an HTML file, in other words, as a Web page. For example,
-*MyCsoundPiece.csd* will produce
-[MyCsoundPiece.csd.html.](http://MyCsoundPiece.csd.html) The front
-end's embedded browser then loads this Web page, compiles it, displays
-it, executes any scripts contained in it, and lets the user interact
-with it.
+For a .html piece, the front end renders the HTML as a Web page and displays 
+it in an embedded Web browser. The front end injects an instance of Csound 
+into the JavaScript context of the Web.
+
+For a .csd piece, the front end parses the `<html>` element out of the .csd 
+file. The front end then loads this Web page into its embedded browser, and 
+injects the same instance of Csound that is running the .csd into the 
+JavaScript context of the Web page.
 
 It is important to understand that *any* valid HTML code can be used in
 Csound\'s `<html>` element. It is just a Web page like any other Web
@@ -147,11 +144,12 @@ documents by programmatically creating Document Object Model objects.
 JavaScript is the engine and the major programming language of the World
 Wide Web in general, and of code that runs in Web browsers in
 particular. JavaScript is a standardized language, and it is a
-functional programming language not that dissimilar in concept from
-Scheme. JavaScript also allows classes to be defined by prototypes.
+functional programming language similar to Scheme. JavaScript also allows 
+classes to be defined by prototypes.
 
 The JavaScript execution context of a Csound Web page contains Csound
-itself as a *csound* JavaScript object that has the following methods:
+itself as a *csound* JavaScript object that has at least the following 
+methods:
 
     getVersion() [returns a number]
     compileOrc(orchestra_code) and
@@ -169,10 +167,9 @@ The front end contains a mechanism for forwarding JavaScript calls in
 the Web page's JavaScript context to native functions that are defined
 in the front end, which passes them on to Csound. This involves a small
 amount of C++ glue code that the user does not need to know about. In
-CsoundQt, the glue code uses asynchronous IPC because the Chromium
-Embedded Framework forks several threads or even processes to implement
-the Web browser, but again, the user does not need to know anything
-about this.
+CsoundQt, the glue code uses some JavaScript proxy generator that is 
+injected into the JavaScript context of the Web page, but again, the user does 
+not need to know anything about this.
 
 In the future, more functions from the Csound API will be added to this
 JavaScript interface, including, at least in some front ends, the
@@ -180,30 +177,15 @@ ability for Csound to appear as a Node in a Web Audio graph (this
 already is possible in the Emscripten built of Csound).
 
 
-Installation
-------------
-
-On Windows, simply download the current Csound installer from
-SourceForge and use it to install Csound on your computer. HTML is
-enabled by default in CsoundQt, which is included in the installer.
-
-On Android, simply download the current Csound6.apk from SourceForge and
-use it to install Csound on your Android device. This can be any
-reasonably powerful Android smartphone or tablet. HTML is enabled by
-default, but the HTML5 features that are available will depend upon your
-version of Android.
-
-Currently, WebGL may or may not be enabled on Android, depending on your
-versions of hardware and software.
-
-
 Tutorial User Guide
 --------------------
 
+Here we will use CsoundQt to run Csound with HTML.
+
 Let's get started and do a few things in the simplest possible way, in
-a series of *toots*. These pieces also are included in the
-examples/html directory of the Windows installation and can be found in
-the Csound Git repository as well.
+a series of *toots*. All of these pieces are completely contained in unfolding 
+boxes here, from which they can be copied and then pasted into the CsoundQt 
+editor, and some pieces are included as HTML examples in CsoundQt.
 
 1.  Display \"Hello, World, this is Csound!\" in HTML.
 2.  Create a button that will generate a series of notes based on the
@@ -214,12 +196,15 @@ the Csound Git repository as well.
     the FM instrument that plays the notes from the logistic equation.
 4.  Style the HTML elements using a style sheet.
 
+### HelloWorld.csd
 
-
-   ***EXAMPLE 12G01_HelloWorld.csd***
-
-This is the bare minimum CSD that shows some HTML output. In its
+This is about the shortest CSD that shows some HTML output. In its
 entirety it is:
+
+<details>
+    <summary>
+    Click to expand code
+    </summary>
 
 ~~~
 <CsoundSynthesizer>
@@ -235,25 +220,644 @@ nchnls = 2
 Hello, World, this is Csound!
 </html>
 <CsScore>
+f 0 10
 </CsScore>
 </CsoundSynthesizer>
 ;example by Michael Gogins
 ~~~
 
+</details>
 
-Not much to it. HTML is full of graceful defaults. In HTML, plain text
-without any tags is imply printed as plain text.
+### Minimal_HTML_Example.csd
 
+This is a simple example that shows how to control Csound using an HTML slider.
 
-### 02_ScoreGenerator.csd
+<details>
+    <summary>
+    Click to expand code
+    </summary>
+
+~~~
+; Minimal example about using html section in CSD
+; by Tarmo Johannes trmjhnns@gmail.com 2016
+
+<CsoundSynthesizer>
+<CsOptions>
+-odac -d
+</CsOptions>
+<html>
+  <head>
+  </head>
+  <body bgcolor="lightblue">
+  <script>
+  function onGetControlChannelCallback(value) {
+    document.getElementById('testChannel').innerHTML = value;
+   } // to test csound.getControlChannel with QtWebEngine 
+  </script>
+   <h2>Minimal Csound-Html5 example</h2><br>
+   <br>
+   Frequency: 
+   <input type="range" id="slider" oninput='csound.setControlChannel("testChannel",this.value/100.0); '></input><br>
+    <button id="button" onclick='csound.readScore("i 1 0 3")' >Event</button>
+   <br><br>
+   Get channel from csound with callback (QtWebchannel): <label id="getchannel"></label> <button onclick='csound.getControlChannel("testChannel", onGetControlChannelCallback)' >Get</button><br>
+        Value from channel "testChannel":  <label id="testChannel"></label><br>
+   <br>
+    Get as return value (QtWebkit) <button onclick='alert("TestChannel: "+csound.getControlChannel("testChannel"))'>Get as retrun value</button>
+
+   <br>
+  </body>
+</html>
+<CsInstruments>
+
+sr = 44100
+nchnls = 2
+0dbfs = 1
+ksmps = 32
+
+chnset 0.5, "testChannel" ; to test chnget in the host
+
+instr 1 
+  kfreq= 200+chnget:k("testChannel")*500	
+  printk2 kfreq
+  aenv linen 1,0.1,p3,0.25
+  out poscil(0.5,kfreq)*aenv
+endin
+
+; schedule 1,0,0.1, 1
+
+</CsInstruments>
+<CsScore>
+i 1 0 0.5 ; to hear if Csound is loaded
+f 0 3600
+</CsScore>
+</CsoundSynthesizer>
+
+~~~
+
+</details>
+
+### Styled_Sliders.csd
+
+And now a more complete example where the user controls both 
+the compositional algorithm, the logistic equation, and the sounds 
+of the instruments. In addition, HTML styles are used to create a more 
+pleasing user interface.
+
+First the entire piece is presented, then the parts are discussed 
+separately.
+
+<details>
+    <summary>
+    Click to expand code
+    </summary>
+
+~~~
+; Example about using CSS in html section of CSD
+; By Michael Gogins 2016
+
+<CsoundSynthesizer>
+<CsOptions>
+-odac
+</CsOptions>
+<CsInstruments>
+
+sr                              =                       44100
+ksmps                           =                       32
+nchnls                          =                       2
+iampdbfs                        init                    32768
+                                prints                  "Default amplitude at 0 dBFS:  %9.4f\n", iampdbfs
+idbafs                          init                    dbamp(iampdbfs)
+                                prints                  "dbA at 0 dBFS:                 %9.4f\n", idbafs
+iheadroom                       init                    6
+                                prints                  "Headroom (dB):                 %9.4f\n", iheadroom
+idbaheadroom                    init                    idbafs - iheadroom
+                                prints                  "dbA at headroom:               %9.4f\n", idbaheadroom
+iampheadroom                    init                    ampdb(idbaheadroom)
+                                prints                  "Amplitude at headroom:        %9.4f\n", iampheadroom
+                                prints                  "Balance so the overall amps at the end of performance -6 dbfs.\n"
+
+                                connect                  "ModerateFM", "outleft", "Reverberation", "inleft"
+                                connect                  "ModerateFM", "outright", "Reverberation", "inright"
+                                connect                  "Reverberation", "outleft", "MasterOutput", "inleft"
+                                connect                  "Reverberation", "outright", "MasterOutput", "inright"
+
+                                alwayson                 "Reverberation"
+                                alwayson                 "MasterOutput"
+                                alwayson                 "Controls"
+
+gk_FmIndex                      init                    0.5
+gk_FmCarrier                    init                    1
+                                instr                   ModerateFM
+                                //////////////////////////////////////////////
+                                // By Michael Gogins.
+                                //////////////////////////////////////////////
+i_instrument                    =                       p1
+i_time                          =                       p2
+i_duration                      =                       p3
+i_midikey                       =                       p4
+i_midivelocity                  =                       p5
+i_phase                         =                       p6
+i_pan                           =                       p7
+i_depth                         =                       p8
+i_height                        =                       p9
+i_pitchclassset                 =                       p10
+i_homogeneity                   =                       p11
+iattack			              =			            0.002
+isustain		                   =			            p3
+idecay				          =			            8
+irelease		                  =			            0.05
+iHz                             =                       cpsmidinn(i_midikey)
+idB                             =                       i_midivelocity
+iamplitude                      =                       ampdb(idB) * 4.0
+kcarrier                	    =                       gk_FmCarrier
+imodulator              	    =                       0.5
+ifmamplitude            	    =                       0.25
+kindex                   	    =                       gk_FmIndex * 20
+ifrequencyb             	    =                       iHz * 1.003
+kcarrierb               	    =                       kcarrier * 1.004
+aindenv                 	    transeg                 0.0, iattack, -11.0, 1.0, idecay, -7.0, 0.025, isustain, 0.0, 0.025, irelease, -7.0, 0.0
+aindex                  	    =                       aindenv * kindex * ifmamplitude
+isinetable                      ftgenonce               0, 0, 65536, 10, 1, 0, .02
+; ares                  	    foscili                 xamp, kcps, xcar, xmod, kndx, ifn [, iphs]
+aouta                   	    foscili                 1.0, iHz, kcarrier, imodulator, kindex / 4., isinetable
+aoutb                   	    foscili                 1.0, ifrequencyb, kcarrierb, imodulator, kindex, isinetable
+; Plus amplitude correction.
+asignal               		    =                       (aouta + aoutb) * aindenv
+adeclick                        linsegr                 0, iattack, 1, isustain, 1, irelease, 0
+asignal                         =                       asignal * iamplitude
+aoutleft, aoutright             pan2                    asignal * adeclick, i_pan
+                                outleta                 "outleft",  aoutleft
+                                outleta                 "outright", aoutright
+                                prints                  "instr %4d t %9.4f d %9.4f k %9.4f v %9.4f p %9.4f\n", p1, p2, p3, p4, p5, p7
+                                endin
+
+gkReverberationWet              init                    .5
+gk_ReverberationDelay            init                    .6
+                                instr                   Reverberation
+ainleft                         inleta                  "inleft"
+ainright                        inleta                  "inright"
+aoutleft                        =                       ainleft
+aoutright                       =                       ainright
+kdry				              =			            1.0 - gkReverberationWet
+awetleft, awetright             reverbsc                ainleft, ainright, gk_ReverberationDelay, 18000.0
+aoutleft			              =			            ainleft *  kdry + awetleft  * gkReverberationWet
+aoutright			         =			            ainright * kdry + awetright * gkReverberationWet
+                                outleta                 "outleft", aoutleft
+                                outleta                 "outright", aoutright
+                                prints                  "instr %4d t %9.4f d %9.4f k %9.4f v %9.4f p %9.4f\n", p1, p2, p3, p4, p5, p7
+                                endin
+
+gk_MasterLevel                   init                   1
+                               instr                   MasterOutput
+ainleft                         inleta                  "inleft"
+ainright                        inleta                  "inright"
+aoutleft                        =                       gk_MasterLevel * ainleft
+aoutright                       =                       gk_MasterLevel * ainright
+                                outs                    aoutleft, aoutright
+                                prints                  "instr %4d t %9.4f d %9.4f k %9.4f v %9.4f p %9.4f\n", p1, p2, p3, p4, p5, p7
+                                endin
+
+instr Controls
+
+gk_FmIndex_ chnget "gk_FmIndex"
+if gk_FmIndex_  != 0 then
+ gk_FmIndex = gk_FmIndex_
+endif
+
+gk_FmCarrier_ chnget "gk_FmCarrier"
+if gk_FmCarrier_  != 0 then
+ gk_FmCarrier = gk_FmCarrier_
+endif
+
+gk_ReverberationDelay_ chnget "gk_ReverberationDelay"
+if gk_ReverberationDelay_  != 0 then
+ gk_ReverberationDelay = gk_ReverberationDelay_
+endif
+
+gk_MasterLevel_ chnget "gk_MasterLevel"
+if gk_MasterLevel_  != 0 then
+ gk_MasterLevel = gk_MasterLevel_
+endif
+
+endin
+
+</CsInstruments>
+<html>
+<head>
+</head>
+<style type="text/css">
+input[type='range'] {
+    -webkit-appearance: none;
+    border-radius: 5px;
+    box-shadow: inset 0 0 5px #333;
+    background-color: #999;
+    height: 10px;
+    width: 100%;
+    vertical-align: middle;
+}
+input[type=range]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    border: none;
+    height: 16px;
+    width: 16px;
+    border-radius: 50%;
+    background: yellow;
+    margin-top: -4px;
+    border-radius: 10px;
+}
+table td {
+    border-width: 2px;
+    padding: 8px;
+    border-style: solid;
+    border-color: transparent;
+    color:yellow;
+    background-color: teal;
+    font-family: sans-serif
+}
+</style>
+
+<h1>Score Generator</h1>
+
+<script>
+
+var c = 0.99;
+var y = 0.5;
+function generate() {
+    csound.message("generate()...\n");
+    for (i = 0; i < 50; i++) {
+      var t = i * (1.0 / 3.0);
+      var y1 = 4.0 * c * y * (1.0 - y);
+      y = y1;
+      var key = Math.round(36.0 + (y * 60.0));
+      var note = "i 1 " + t + " 2.0 " + key + " 60 0.0 0.5\n";
+      csound.readScore(note);
+    };
+};
+
+function on_sliderC(value) {
+    c = parseFloat(value);
+    document.querySelector('#sliderCOutput').value = c;
+}
+
+function on_sliderFmIndex(value) {
+    var numberValue = parseFloat(value);
+    document.querySelector('#sliderFmIndexOutput').value = numberValue;
+    csound.setControlChannel('gk_FmIndex', numberValue);
+}
+
+function on_sliderFmRatio(value) {
+    var numberValue = parseFloat(value);
+    document.querySelector('#sliderFmRatioOutput').value = numberValue;
+    csound.setControlChannel('gk_FmCarrier', numberValue);
+}
+
+function on_sliderReverberationDelay(value) {
+    var numberValue = parseFloat(value);
+    document.querySelector('#sliderReverberationDelayOutput').value = numberValue;
+    csound.setControlChannel('gk_ReverberationDelay', numberValue);
+}
+
+function on_sliderMasterLevel(value) {
+    var numberValue = parseFloat(value);
+    document.querySelector('#sliderMasterLevelOutput').value = numberValue;
+    csound.setControlChannel('gk_MasterLevel', numberValue);
+}
+
+</script>
+
+<table>
+<col width="2*">
+<col width="5*">
+<col width="100px">
+
+<tr>
+<td>
+<label for=sliderC>c</label>
+<td>
+<input type=range min=0 max=1 value=.5 id=sliderC step=0.001 oninput="on_sliderC(value)">
+<td>
+<output for=sliderC id=sliderCOutput>.5</output>
+</tr>
+
+<tr>
+<td>
+<label for=sliderFmIndex>Frequency modulation index</label>
+<td>
+<input type=range min=0 max=1 value=.5 id=sliderC step=0.001 oninput="on_sliderFmIndex(value)">
+<td>
+<output for=sliderFmIndex id=sliderFmIndexOutput>.5</output>
+</tr>
+
+<tr>
+<td>
+<label for=sliderFmRatio>Frequency modulation ratio</label>
+<td>
+<input type=range min=0 max=1 value=.5 id=sliderFmRatio step=0.001 oninput="on_sliderFmRatio(value)">
+<td>
+<output for=sliderFmRatio id=sliderFmRatioOutput>.5</output>
+</tr>
+
+<tr>
+<td>
+<label for=sliderReverberationDelay>Reverberation delay</label>
+<td>
+<input type=range min=0 max=1 value=.5 id=sliderReverberationDelay step=0.001 oninput="on_sliderReverberationDelay(value)">
+<td>
+<output for=sliderReverberationDelay id=sliderReverberationDelayOutput>.5</output>
+</tr>
+
+<tr>
+<td>
+<label for=sliderMasterLevel>Master output level</label>
+<td>
+<input type=range min=0 max=1 value=.5 id=sliderMasterLevel step=0.001 oninput="on_sliderMasterLevel(value)">
+<td>
+<output for=sliderMasterLevel id=sliderMasterLevelOutput>.5</output>
+</tr>
+
+<tr>
+<td>
+<button onclick="generate()"> Generate score </button>
+</td>
+</tr>
+
+</table>
+
+</html>
+<CsScore>
+</CsScore>
+</CsoundSynthesizer>
+         prints                  "dbA at headroom:               %9.4f\n", idbaheadroom
+iampheadroom                    init                    ampdb(idbaheadroom)
+                                prints                  "Amplitude at headroom:        %9.4f\n", iampheadroom
+                                prints                  "Balance so the overall amps at the end of performance -6 dbfs.\n"
+
+                                connect                  "ModerateFM", "outleft", "Reverberation", "inleft"
+                                connect                  "ModerateFM", "outright", "Reverberation", "inright"
+                                connect                  "Reverberation", "outleft", "MasterOutput", "inleft"
+                                connect                  "Reverberation", "outright", "MasterOutput", "inright"
+
+                                alwayson                 "Reverberation"
+                                alwayson                 "MasterOutput"
+                                alwayson                 "Controls"
+
+gk_FmIndex                      init                    0.5
+gk_FmCarrier                    init                    1
+                                instr                   ModerateFM
+                                //////////////////////////////////////////////
+                                // By Michael Gogins.
+                                //////////////////////////////////////////////
+i_instrument                    =                       p1
+i_time                          =                       p2
+i_duration                      =                       p3
+i_midikey                       =                       p4
+i_midivelocity                  =                       p5
+i_phase                         =                       p6
+i_pan                           =                       p7
+i_depth                         =                       p8
+i_height                        =                       p9
+i_pitchclassset                 =                       p10
+i_homogeneity                   =                       p11
+iattack			              =			            0.002
+isustain		                   =			            p3
+idecay				          =			            8
+irelease		                  =			            0.05
+iHz                             =                       cpsmidinn(i_midikey)
+idB                             =                       i_midivelocity
+iamplitude                      =                       ampdb(idB) * 4.0
+kcarrier                	    =                       gk_FmCarrier
+imodulator              	    =                       0.5
+ifmamplitude            	    =                       0.25
+kindex                   	    =                       gk_FmIndex * 20
+ifrequencyb             	    =                       iHz * 1.003
+kcarrierb               	    =                       kcarrier * 1.004
+aindenv                 	    transeg                 0.0, iattack, -11.0, 1.0, idecay, -7.0, 0.025, isustain, 0.0, 0.025, irelease, -7.0, 0.0
+aindex                  	    =                       aindenv * kindex * ifmamplitude
+isinetable                      ftgenonce               0, 0, 65536, 10, 1, 0, .02
+; ares                  	    foscili                 xamp, kcps, xcar, xmod, kndx, ifn [, iphs]
+aouta                   	    foscili                 1.0, iHz, kcarrier, imodulator, kindex / 4., isinetable
+aoutb                   	    foscili                 1.0, ifrequencyb, kcarrierb, imodulator, kindex, isinetable
+; Plus amplitude correction.
+asignal               		    =                       (aouta + aoutb) * aindenv
+adeclick                        linsegr                 0, iattack, 1, isustain, 1, irelease, 0
+asignal                         =                       asignal * iamplitude
+aoutleft, aoutright             pan2                    asignal * adeclick, i_pan
+                                outleta                 "outleft",  aoutleft
+                                outleta                 "outright", aoutright
+                                prints                  "instr %4d t %9.4f d %9.4f k %9.4f v %9.4f p %9.4f\n", p1, p2, p3, p4, p5, p7
+                                endin
+
+gkReverberationWet              init                    .5
+gk_ReverberationDelay            init                    .6
+                                instr                   Reverberation
+ainleft                         inleta                  "inleft"
+ainright                        inleta                  "inright"
+aoutleft                        =                       ainleft
+aoutright                       =                       ainright
+kdry				              =			            1.0 - gkReverberationWet
+awetleft, awetright             reverbsc                ainleft, ainright, gk_ReverberationDelay, 18000.0
+aoutleft			              =			            ainleft *  kdry + awetleft  * gkReverberationWet
+aoutright			         =			            ainright * kdry + awetright * gkReverberationWet
+                                outleta                 "outleft", aoutleft
+                                outleta                 "outright", aoutright
+                                prints                  "instr %4d t %9.4f d %9.4f k %9.4f v %9.4f p %9.4f\n", p1, p2, p3, p4, p5, p7
+                                endin
+
+gk_MasterLevel                   init                   1
+                               instr                   MasterOutput
+ainleft                         inleta                  "inleft"
+ainright                        inleta                  "inright"
+aoutleft                        =                       gk_MasterLevel * ainleft
+aoutright                       =                       gk_MasterLevel * ainright
+                                outs                    aoutleft, aoutright
+                                prints                  "instr %4d t %9.4f d %9.4f k %9.4f v %9.4f p %9.4f\n", p1, p2, p3, p4, p5, p7
+                                endin
+
+instr Controls
+
+gk_FmIndex_ chnget "gk_FmIndex"
+if gk_FmIndex_  != 0 then
+ gk_FmIndex = gk_FmIndex_
+endif
+
+gk_FmCarrier_ chnget "gk_FmCarrier"
+if gk_FmCarrier_  != 0 then
+ gk_FmCarrier = gk_FmCarrier_
+endif
+
+gk_ReverberationDelay_ chnget "gk_ReverberationDelay"
+if gk_ReverberationDelay_  != 0 then
+ gk_ReverberationDelay = gk_ReverberationDelay_
+endif
+
+gk_MasterLevel_ chnget "gk_MasterLevel"
+if gk_MasterLevel_  != 0 then
+ gk_MasterLevel = gk_MasterLevel_
+endif
+
+endin
+
+</CsInstruments>
+<html>
+<head>
+</head>
+<style type="text/css">
+input[type='range'] {
+    -webkit-appearance: none;
+    border-radius: 5px;
+    box-shadow: inset 0 0 5px #333;
+    background-color: #999;
+    height: 10px;
+    width: 100%;
+    vertical-align: middle;
+}
+input[type=range]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    border: none;
+    height: 16px;
+    width: 16px;
+    border-radius: 50%;
+    background: yellow;
+    margin-top: -4px;
+    border-radius: 10px;
+}
+table td {
+    border-width: 2px;
+    padding: 8px;
+    border-style: solid;
+    border-color: transparent;
+    color:yellow;
+    background-color: teal;
+    font-family: sans-serif
+}
+</style>
+
+<h1>Score Generator</h1>
+
+<script>
+
+var c = 0.99;
+var y = 0.5;
+function generate() {
+    csound.message("generate()...\n");
+    for (i = 0; i < 50; i++) {
+      var t = i * (1.0 / 3.0);
+      var y1 = 4.0 * c * y * (1.0 - y);
+      y = y1;
+      var key = Math.round(36.0 + (y * 60.0));
+      var note = "i 1 " + t + " 2.0 " + key + " 60 0.0 0.5\n";
+      csound.readScore(note);
+    };
+};
+
+function on_sliderC(value) {
+    c = parseFloat(value);
+    document.querySelector('#sliderCOutput').value = c;
+}
+
+function on_sliderFmIndex(value) {
+    var numberValue = parseFloat(value);
+    document.querySelector('#sliderFmIndexOutput').value = numberValue;
+    csound.setControlChannel('gk_FmIndex', numberValue);
+}
+
+function on_sliderFmRatio(value) {
+    var numberValue = parseFloat(value);
+    document.querySelector('#sliderFmRatioOutput').value = numberValue;
+    csound.setControlChannel('gk_FmCarrier', numberValue);
+}
+
+function on_sliderReverberationDelay(value) {
+    var numberValue = parseFloat(value);
+    document.querySelector('#sliderReverberationDelayOutput').value = numberValue;
+    csound.setControlChannel('gk_ReverberationDelay', numberValue);
+}
+
+function on_sliderMasterLevel(value) {
+    var numberValue = parseFloat(value);
+    document.querySelector('#sliderMasterLevelOutput').value = numberValue;
+    csound.setControlChannel('gk_MasterLevel', numberValue);
+}
+
+</script>
+
+<table>
+<col width="2*">
+<col width="5*">
+<col width="100px">
+
+<tr>
+<td>
+<label for=sliderC>c</label>
+<td>
+<input type=range min=0 max=1 value=.5 id=sliderC step=0.001 oninput="on_sliderC(value)">
+<td>
+<output for=sliderC id=sliderCOutput>.5</output>
+</tr>
+
+<tr>
+<td>
+<label for=sliderFmIndex>Frequency modulation index</label>
+<td>
+<input type=range min=0 max=1 value=.5 id=sliderC step=0.001 oninput="on_sliderFmIndex(value)">
+<td>
+<output for=sliderFmIndex id=sliderFmIndexOutput>.5</output>
+</tr>
+
+<tr>
+<td>
+<label for=sliderFmRatio>Frequency modulation ratio</label>
+<td>
+<input type=range min=0 max=1 value=.5 id=sliderFmRatio step=0.001 oninput="on_sliderFmRatio(value)">
+<td>
+<output for=sliderFmRatio id=sliderFmRatioOutput>.5</output>
+</tr>
+
+<tr>
+<td>
+<label for=sliderReverberationDelay>Reverberation delay</label>
+<td>
+<input type=range min=0 max=1 value=.5 id=sliderReverberationDelay step=0.001 oninput="on_sliderReverberationDelay(value)">
+<td>
+<output for=sliderReverberationDelay id=sliderReverberationDelayOutput>.5</output>
+</tr>
+
+<tr>
+<td>
+<label for=sliderMasterLevel>Master output level</label>
+<td>
+<input type=range min=0 max=1 value=.5 id=sliderMasterLevel step=0.001 oninput="on_sliderMasterLevel(value)">
+<td>
+<output for=sliderMasterLevel id=sliderMasterLevelOutput>.5</output>
+</tr>
+
+<tr>
+<td>
+<button onclick="generate()"> Generate score </button>
+</td>
+</tr>
+
+</table>
+
+</html>
+<CsScore>
+</CsScore>
+</CsoundSynthesizer>
+
+~~~
+</details>
 
 Here I have introduced a simple Csound orchestra consisting of a single
 frequency modulation instrument feeding first into a reverberation
 effect, and then into a master output unit. These are connected using
 the signal flow graph opcodes. The actual orchestra is of little
-interest here. And this piece has no score, because the score will be
-generated at run time. In the `<html>` element, I also have added this
-button:
+interest here. 
+
+#### Generating the Score
+
+This piece has no score, because the score will be generated at run time. 
+In the `<html>` element, I also have added this button:
 
     <button onclick="generate()"> Generate score </button>
 
@@ -283,7 +887,7 @@ element is added to the body of the `<html>` element:
     </script>
 
 
-### 03_Sliders.csd
+#### Adding Sliders
 
 The next step is to add more user control to this piece. We will enable
 the user to control the attractor of the piece by varying the constant
@@ -402,7 +1006,7 @@ Note that each actual global variable has a default value, which is only
 overridden if the user actually operates its slider.
 
 
-### 04_CustomStyle.csd
+#### Customizing the Style
 
 The default appearance of HTML elements is brutally simple. But each
 element has attributes that can be used to change its appearance, and


### PR DESCRIPTION
I have now updated both the Android and the HTML section.

In the HTML section, I removed the previous examples, the 3D Game of LIfe and the Lindenmayer Canvas pieces, because I could not find versions of these older pieces that still run. I have replaced them with a WebAssembly version of my piece ***Scrims***, which runs directly in the FLOSS manual page. 

This will only work for HTML versions of the FLOSS manual. If you are planning to create PDF or EPub versions of the manual, a static image of this piece with a link to the online version will have to be provided for those versions.

For the tutorial section of this chapter, I have replaced the existing material with a single piece, which is one of the example pieces in CsoundQt. The code for the whole piece is collapsed in a Details element. Then, I explain the sections of code as in the previous tutorials.
