### PR TITLE
Update 03-d-function-tables.md

### DIFF
--- a/book/03-d-function-tables.md
+++ b/book/03-d-function-tables.md
@@ -175,7 +175,7 @@ The syntax is explained below:
 
     giVar     ftgen     ifn, itime, isize, igen, iarg1 [, iarg2 [, ...]]
 
--   ***giVar***: a variable name. Each function is stored in an
+-   ***gir***: a variable name. Each function is stored in an
     i-variable. Usually you want to have access to it from every
     instrument, so a gi-variable (global initialization variable) is
     given.


### PR DESCRIPTION
I think "gir" is better than "giVar" because "giVar" does not exist in the code (there are "giFt1" and "giFt2" in code) and not in the canonical reference manual ("gir" is in manual) too, so it can be ambiguous. Thanks.