### PR TITLE
Update 04-g-physical-modelling.md

### DIFF
--- a/book/04-g-physical-modelling.md
+++ b/book/04-g-physical-modelling.md
@@ -1047,27 +1047,27 @@ aL,aR   pan2            aSig,kPan
 ;t 0 90 1 30 2 60 5 90 7 30
 ; p4 = stiffness (pitch)
 
-\#define gliss(dur'Kstrt'Kend'b'scan1'scan2)
-\#
+#define gliss(dur'Kstrt'Kend'b'scan1'scan2)
+#
 i 1 0     20 $Kstrt $b $scan1 $scan2
-i 1 \^+0.05 $dur >     $b $scan1 $scan2
-i 1 \^+0.05 $dur >     $b $scan1 $scan2
-i 1 \^+0.05 $dur >     $b $scan1 $scan2
-i 1 \^+0.05 $dur >     $b $scan1 $scan2
-i 1 \^+0.05 $dur >     $b $scan1 $scan2
-i 1 \^+0.05 $dur >     $b $scan1 $scan2
-i 1 \^+0.05 $dur >     $b $scan1 $scan2
-i 1 \^+0.05 $dur >     $b $scan1 $scan2
-i 1 \^+0.05 $dur >     $b $scan1 $scan2
-i 1 \^+0.05 $dur >     $b $scan1 $scan2
-i 1 \^+0.05 $dur >     $b $scan1 $scan2
-i 1 \^+0.05 $dur >     $b $scan1 $scan2
-i 1 \^+0.05 $dur >     $b $scan1 $scan2
-i 1 \^+0.05 $dur >     $b $scan1 $scan2
-i 1 \^+0.05 $dur >     $b $scan1 $scan2
-i 1 \^+0.05 $dur >     $b $scan1 $scan2
-i 1 \^+0.05 $dur $Kend $b $scan1 $scan2
-\#
+i 1 ^+0.05 $dur >     $b $scan1 $scan2
+i 1 ^+0.05 $dur >     $b $scan1 $scan2
+i 1 ^+0.05 $dur >     $b $scan1 $scan2
+i 1 ^+0.05 $dur >     $b $scan1 $scan2
+i 1 ^+0.05 $dur >     $b $scan1 $scan2
+i 1 ^+0.05 $dur >     $b $scan1 $scan2
+i 1 ^+0.05 $dur >     $b $scan1 $scan2
+i 1 ^+0.05 $dur >     $b $scan1 $scan2
+i 1 ^+0.05 $dur >     $b $scan1 $scan2
+i 1 ^+0.05 $dur >     $b $scan1 $scan2
+i 1 ^+0.05 $dur >     $b $scan1 $scan2
+i 1 ^+0.05 $dur >     $b $scan1 $scan2
+i 1 ^+0.05 $dur >     $b $scan1 $scan2
+i 1 ^+0.05 $dur >     $b $scan1 $scan2
+i 1 ^+0.05 $dur >     $b $scan1 $scan2
+i 1 ^+0.05 $dur >     $b $scan1 $scan2
+i 1 ^+0.05 $dur $Kend $b $scan1 $scan2
+#
 $gliss(15'40'400'0.0755'0.1'2)
 b 5
 $gliss(2'80'800'0.755'0'0.1)


### PR DESCRIPTION
### example_04G11_barmodel.csd

This is another conversion error i think "  leftovers from latex special-char escaping " ( https://github.com/csound-flossmanual/csound-floss/issues/49#issuecomment-701582588 )

Here is what it looks like in the pdf,  (just the area of the syntax errors) .
![image](https://user-images.githubusercontent.com/619340/95064975-ba2f7980-0700-11eb-8566-fab6f164e1a1.png)

but it should look like (without slashes), from csoundQT

![image](https://user-images.githubusercontent.com/619340/95065047-cfa4a380-0700-11eb-8978-fdb0259f2255.png)

confirmed, without the slashes it works.