### PR TITLE
minor spelling fixes

### DIFF
--- a/book/01-GS-01.md
+++ b/book/01-GS-01.md
@@ -116,7 +116,7 @@ In Csound, all oscillators, filters, sample players and other processing units
 are encapsulated in an **instrument**. An instrument has the
 keyword `instr` at its start, and `endin` at its end.
 
-After the keyword `instr`, seperated by a space, we assign a number (1, 2, 3, ...) or a
+After the keyword `instr`, separated by a space, we assign a number (1, 2, 3, ...) or a
 name to the instrument. Let us call our instrument "Hello", and include the
 code which we discussed:
 

--- a/book/01-GS-02.md
+++ b/book/01-GS-02.md
@@ -222,7 +222,7 @@ For instance this code:
 
     kFreq = linseg:k(500 0.5 400)
 
-What is illegal here? We have seperated the three input arguments
+What is illegal here? We have separated the three input arguments
 for `linseg` not by commas, but by spaces. Csound expects commas,
 and if there is no comma, it returns a syntax error,
 and the code cannot be compiled:

--- a/book/01-GS-07.md
+++ b/book/01-GS-07.md
@@ -213,7 +213,7 @@ https://ia801707.us.archive.org/13/items/an-introductory-catalogue-of-computer-s
 The early versions of Max Mathews _MUSIC_ program could only run on one particular
 computer. The "C" in Csound points to the
 [C Programming Language](<https://en.wikipedia.org/wiki/C_(programming_language)>)
-which was first released in 1972. It made it possible to seperate the source code
+which was first released in 1972. It made it possible to separate the source code
 which is written and can be read by humans from a specific
 machine on which it runs. C is still a very successful language, used
 for everything which must be fast, like operating systems or audio applications.

--- a/book/01-GS-08.md
+++ b/book/01-GS-08.md
@@ -24,7 +24,7 @@ that the Csound _.csd_ file consists of three sections:
 On one hand, this is a reasonable division of jobs. In the `CsInstruments` we
 code the instruments, in the `CsScore` we call them, and in the `CsOptions` we
 determine some general settings about the performance. In early times of Csound,
-the instrument definitions and the score resided in two seperated text files.
+the instrument definitions and the score resided in two separated text files.
 The instrument definitions, or orchestra, were collected in an _.orc_ file,
 and the score lines were collected in a _.sco_ file. The options were put in
 so called "flags" which you still see in the `CsOptions`. The `-o` flag, for

--- a/book/02-c-hardware.md
+++ b/book/02-c-hardware.md
@@ -60,7 +60,7 @@ Csound on the command line or via API.
 Remember that you also need to choose a real-time audio module.
 (See above how to do this.)
 
-Csound connects with a specific sound card seperately for input and output.
+Csound connects with a specific sound card separately for input and output.
 
 #### Output
 

--- a/book/03-a-initialization-and-performance-pass.md
+++ b/book/03-a-initialization-and-performance-pass.md
@@ -1142,7 +1142,7 @@ The rise and the decay are each 1/10 seconds long. If this envelope is
 produced at k-rate with a blocksize of 128 (instr 1), the noise is
 clearly audible. Try changing ksmps to 64, 32 or 16 and compare the
 amount of zipper noise. — Instrument 2 uses an envelope at audio-rate
-instead. Regardless the blocksize, each sample is calculated seperately,
+instead. Regardless the blocksize, each sample is calculated separately,
 so the envelope will always be smooth. — Instrument 3 shows a remedy for situations in which a k-rate envelope cannot be avoided: the [a()](https://csound.com/docs/manual/opa.html) will convert the k-signal to audio-rate by interpolation thus smoothing the envelope.
 
 #### **_EXAMPLE 03A18_Zipper.csd_**

--- a/book/03-c-control-structures.md
+++ b/book/03-c-control-structures.md
@@ -1264,7 +1264,7 @@ to the _timout_ feature:
 - You must select the one k-cycle where the _metro_ opcode sends
   a _1_. This is done with an if-statement. The rest of the
   instrument is not affected. If you use _timout_, you
-  usually must seperate the reinitialized from the not reinitialized
+  usually must separate the reinitialized from the not reinitialized
   section by a _rireturn_ statement.
 
 ### Time Loops by Using a Clock Variable

--- a/book/15-b-pitch-and-frequency.md
+++ b/book/15-b-pitch-and-frequency.md
@@ -437,7 +437,7 @@ and `cent(-25)` returns the multiplier for calculating an eighth tone lower.
 
 ```csound
     instr 1
-     prints "A quater tone above A4 (440 Hz):\n"
+     prints "A quarter tone above A4 (440 Hz):\n"
      prints " 1. as mtof:i(69.5) = %f\n", mtof:i(69.5)
      prints " 2. as cpspch(8.095) = %f\n", cpspch(8.095)
      prints " 3. as 2^(50/1200)*440 = %f\n", 2^(50/1200)*440
@@ -449,7 +449,7 @@ and `cent(-25)` returns the multiplier for calculating an eighth tone lower.
 The result of this comparison is:
 
 ```
-    A quater tone above A4 (440 Hz):
+    A quarter tone above A4 (440 Hz):
      1. as mtof:i(69.5) = 452.892984
      2. as cpspch(8.095) = 452.880211
      3. as 2^(50/1200)*440 = 452.892984
@@ -470,7 +470,7 @@ are particularily suited for this approach.
 It is even simple to "tune" a MIDI keyboard in quarter tones or to any historical tuning using Csound.
 The following example shows the fundamentals.
 It plays the five notes C D E F G (= MIDI 60 62 64 65 67) first in
-Pythoagorean tuning, then in Meantone, then as quatertones, then as partials 1-5.
+Pythoagorean tuning, then in Meantone, then as quarter tones, then as partials 1-5.
 
 #### **_EXAMPLE 15B05_Tuning_Systems.csd_**
 
@@ -498,10 +498,10 @@ instr Meantone
  puts "Meantone scale",1
 endin
 
-instr Quatertone
+instr Quartertone
  giScale[] fillarray 1, 2^(1/24), 2^(2/24), 2^(3/24), 2^(4/24)
  schedule("LetPlay",0,0)
- puts "Quatertone scale",1
+ puts "Quartertone scale",1
 endin
 
 instr Partials
@@ -530,7 +530,7 @@ endin
 <CsScore>
 i "Pythagorean" 0 10
 i "Meantone" 10 10
-i "Quatertone" 20 10
+i "Quartertone" 20 10
 i "Partials" 30 10
 </CsScore>
 </CsoundSynthesizer>

--- a/contribute/conventions.md
+++ b/contribute/conventions.md
@@ -46,7 +46,7 @@ Few additional languages are supported
 <pre>```python</pre>
 <pre>```c</pre>
 
-The full examples (which are collected and distributed seperately) must be
+The full examples (which are collected and distributed separately) must be
 preceded by four hashes(\#) a number and a title of the example,
 starting with the word EXAMPLE (\#\#\#\# \*\*EXAMPLE\*\*):
 


### PR DESCRIPTION
changes:
* quater tone -> quarter tone
* seperate(ly) -> separate(ly)

closes #93