### PR TITLE
Fixes issue with wrong numbers printing to console in csound for iOS

### DIFF
--- a/book/12-d-csound-in-ios.md
+++ b/book/12-d-csound-in-ios.md
@@ -1008,8 +1008,7 @@ The process demonstrated in the code examples below can be described as:
 }
 ```
 
-Note that in Swift, we have to create a `CVaListPointer` (equivalent to a
-`va_list *` in C) for use with the `vsnprintf()` function:
+
 
 ```swift
 // Swift
@@ -1017,10 +1016,8 @@ func messageCallback(_ infoObj: NSValue) {
     var info = Message()
     infoObj.getValue(&info)
     let message = UnsafeMutablePointer<Int8>.allocate(capacity: 1024)
-    let va_ptr: CVaListPointer = CVaListPointer(
-      _fromUnsafeMutablePointer: &(info.valist)
-    )
-    vsnprintf(message, 1024, info.format, va_ptr)
+
+    vsnprintf(message, 1024, info.format, info.valist)
     let messageStr = String(cString: message)
     print(messageStr)
 }


### PR DESCRIPTION
I was running into issues when using the supplied code snippet for printing to the Xcode console from iOS using swift. Most numbers were completely off, usually extremely high or negative.
It seems like the extra step for creating a CVaListPointer was messing something (not sure what) up. However, when just using info.valist directly, this works.  As I do not exactly understand why this extra code was there, somebody who knows should check if my change is breaking something that I am unaware of!  As I understand it, the _valist_ in the csound message is already compatible with vsnprintf().
I deleted the corresponding mention of the now deleted extra code in the manual text, too.